### PR TITLE
Fixed bug in task edit. The task path was only accessing the task_list.id, removed the second _list.id and added the task.id

### DIFF
--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -1,4 +1,4 @@
-<%= form_for @task, url: task_list_task_path(@task_list.id, @task_list.id), html: { class: "task-form" } do |f| %>
+<%= form_for @task, url: task_list_task_path(@task_list.id, @task.id), html: { class: "task-form" } do |f| %>
 
   <h2>Add a Task</h2>
 


### PR DESCRIPTION
Would only update the bottom task description when trying to update the first task description.  The task id's were both directed to the task_list.id.  I changed the second one to task.id to access the current id of the task being edited. 
